### PR TITLE
First draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.cpcache
+/.lein-*
+/.nrepl-history
+/.nrepl-port

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["resources" "src"]
- :deps {org.clojure/clojure {:mvn/version "1.10.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.9.0"}
         org.clojure/core.async {:mvn/version "0.4.500"}
         org.clojure/data.json {:mvn/version "0.2.6"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -8,11 +8,12 @@
         lambdaisland/uri {:mvn/version "1.1.0"}
         less-awful-ssl {:mvn/version "1.0.2"}}
  :aliases
- {:test {:extra-paths ["test"]
-         :extra-deps {org.clojure/test.check {:mvn/version "RELEASE"}}}
-  :runner
+ {:test
   {:extra-paths ["test"]
-   :extra-deps {com.cognitect/test-runner
+   :extra-deps {org.clojure/test.check {:mvn/version "RELEASE"}}}
+
+  :runner
+  {:extra-deps {com.cognitect/test-runner
                 {:git/url "https://github.com/cognitect-labs/test-runner"
                  :sha "76568540e7f40268ad2b646110f237a60295fa3c"}}
    :main-opts ["-m" "cognitect.test-runner"

--- a/deps.edn
+++ b/deps.edn
@@ -1,10 +1,9 @@
 {:paths ["resources" "src"]
- :deps {org.clojure/clojure {:mvn/version "RELEASE"}
+ :deps {org.clojure/clojure {:mvn/version "1.8.0"}
         org.clojure/core.async {:mvn/version "0.4.500"}
         org.clojure/data.json {:mvn/version "0.2.6"}
-        org.clojure/spec-alpha2 {:git/url "https://github.com/clojure/spec-alpha2.git"
-                                 :sha "aaadd79b1644bc73d1c4283532a7b59ef382a671"}
-        clj-http {:mvn/version "3.10.0"}
+
+        clj-http-lite {:mvn/version "0.3.0"}
         lambdaisland/uri {:mvn/version "1.1.0"}
         less-awful-ssl {:mvn/version "1.0.2"}}
  :aliases

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,19 @@
+{:paths ["resources" "src"]
+ :deps {org.clojure/clojure {:mvn/version "RELEASE"}
+        org.clojure/core.async {:mvn/version "0.4.500"}
+        org.clojure/data.json {:mvn/version "0.2.6"}
+        org.clojure/spec-alpha2 {:git/url "https://github.com/clojure/spec-alpha2.git"
+                                 :sha "aaadd79b1644bc73d1c4283532a7b59ef382a671"}
+        clj-http {:mvn/version "3.10.0"}
+        lambdaisland/uri {:mvn/version "1.1.0"}
+        less-awful-ssl {:mvn/version "1.0.2"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {org.clojure/test.check {:mvn/version "RELEASE"}}}
+  :runner
+  {:extra-paths ["test"]
+   :extra-deps {com.cognitect/test-runner
+                {:git/url "https://github.com/cognitect-labs/test-runner"
+                 :sha "76568540e7f40268ad2b646110f237a60295fa3c"}}
+   :main-opts ["-m" "cognitect.test-runner"
+               "-d" "test"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,6 @@
         org.clojure/core.async {:mvn/version "0.4.500"}
         org.clojure/data.json {:mvn/version "0.2.6"}
 
-        clj-http-lite {:mvn/version "0.3.0"}
         lambdaisland/uri {:git/url "https://github.com/chris-chambers/uri.git"
                           :sha "9b533a1a892fc3f8a29d9534d4576581fa29dc24"}}
  :aliases

--- a/deps.edn
+++ b/deps.edn
@@ -1,11 +1,11 @@
 {:paths ["resources" "src"]
- :deps {org.clojure/clojure {:mvn/version "1.8.0"}
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.clojure/core.async {:mvn/version "0.4.500"}
         org.clojure/data.json {:mvn/version "0.2.6"}
 
         clj-http-lite {:mvn/version "0.3.0"}
-        lambdaisland/uri {:mvn/version "1.1.0"}
-        less-awful-ssl {:mvn/version "1.0.2"}}
+        lambdaisland/uri {:git/url "https://github.com/chris-chambers/uri.git"
+                          :sha "9b533a1a892fc3f8a29d9534d4576581fa29dc24"}}
  :aliases
  {:test
   {:extra-paths ["test"]

--- a/src/kapibara/core.clj
+++ b/src/kapibara/core.clj
@@ -1,0 +1,136 @@
+(ns kapibara.core
+  "The core of Kapibara.  Provides low-level access to the Kubernetes API."
+  (:require [clojure.core.async :refer [>!!] :as async]
+            [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [clojure.spec-alpha2 :as s]
+            [clojure.string :as str]
+
+            [clj-http.client :as http]
+            [lambdaisland.uri :refer [uri] :as uri]))
+
+
+(defn make-client
+  ([server] (make-client server nil))
+  ([server options]
+   (merge {:server/uri (uri server)} options)))
+
+
+;; TODO: Support authentication via the following keys
+:auth/username
+:auth/password
+
+:auth/ca-cert
+:auth/client-cert
+:auth/client-key
+
+:auth/oauth-token
+:auth/oauth-token-fn
+
+
+(def ^:private clj-http-key-whitelist
+  [:method :content-type :body :debug?])
+
+
+(defn- request-options
+  [client options]
+  (let [url (str (uri/join (:server/uri client) (:uri options)))
+        req-opts (merge {:url           url
+                         :as            :stream
+                         ;; TODO: Move insecure calculation to wherever
+                         ;;       authentication options are calculated.
+                         :insecure?     true
+                         :save-request? true}
+                        (select-keys options clj-http-key-whitelist))]
+    (if-let [interceptor (:interceptor options)]
+      (interceptor client options req-opts)
+      req-opts)))
+
+
+(defn- read-json-stream
+  [to-chan ^java.io.InputStream from-stream]
+  (loop [rdr (io/reader from-stream)]
+    (let [obj (json/read rdr
+                         :eof-error? false
+                         :key-fn keyword)]
+      (when (and (some? obj)
+                 (>!! to-chan obj))
+        (recur rdr)))))
+
+
+(deftype Request [chan abortfn]
+  clojure.lang.IDeref
+  (deref [this] chan))
+
+
+(defn- abort-fn
+  [^Request req]
+  (.abortfn req))
+
+
+(defn abort!
+  [req]
+  ((abort-fn req)))
+
+(defn request
+  [client options]
+  (let [ch (async/chan)
+        p-request (promise)]
+    (async/thread
+      (try
+        (let [req-opts (request-options client options)
+              resp (http/request req-opts)]
+          (deliver p-request (:request resp))
+          (with-open [body (:body resp)]
+            (read-json-stream ch body)))
+        (catch Exception e
+          (>!! ch {::error e}))
+        (finally
+          (async/close! ch))))
+    (->Request ch (fn [] (.abort (:http-req @p-request))))))
+
+
+(defn update-request-chan
+  [req f & args]
+  (->Request (apply f @req args) (abort-fn req)))
+
+
+;; TODO: It may be necessary for `merge-requests` to invalidate the original
+;;       `Request` objects, since using them after this call could be an error.
+(defn merge-requests
+  [reqs]
+  (let [reqs' (into [] reqs)]
+    (->Request
+     (async/merge (map deref reqs'))
+     (fn [] (run! #(%) (map abort-fn reqs'))))))
+
+
+(comment
+
+  (def client (make-client "http://localhost:8080"))
+
+  (def x (request client
+                  {:method :get
+                   :uri "/api/v1/namespaces/default/configmaps"}))
+
+  (def x (merge-requests
+          [
+           (update-request-chan
+            (request client
+                     {:method :get
+                      :uri "/api/v1/namespaces/default/configmaps/foo"})
+            #(let [ch (async/chan 1 (map (fn [x] :bonk)))]
+               (async/pipe % ch)))
+           (request client
+                    {:method :get
+                     :uri "/api/v1/namespaces/default/configmaps/bar"})]))
+
+  (async/<!! @x)
+
+  (abort! x)
+
+  (async/<!! (async/into [] (request client {:uri "/apis"
+                                             :method :get
+                                             :query {:watch true}})))
+
+  )

--- a/src/kapibara/core.clj
+++ b/src/kapibara/core.clj
@@ -15,16 +15,17 @@
    (merge {:server/uri (uri server)} options)))
 
 
-;; TODO: Support authentication via the following keys
-:auth/username
-:auth/password
+(comment
+  ;; TODO: Support authentication via the following keys
+  :auth/username
+  :auth/password
 
-:auth/ca-cert
-:auth/client-cert
-:auth/client-key
+  :auth/ca-cert
+  :auth/client-cert
+  :auth/client-key
 
-:auth/oauth-token
-:auth/oauth-token-fn
+  :auth/oauth-token
+  :auth/oauth-token-fn)
 
 
 (def ^:private clj-http-key-whitelist
@@ -89,8 +90,8 @@
     (->Request ch (fn []
                     (throw (Exception. "abort! cannot be implemented with clj-http-lite. Waiting on GraalVM 19.3, for JDK 11 and the new HTTPClient"))
                     #_(let [^org.apache.http.client.methods.AbortableHttpRequest req
-                          (:http-req @p-request)]
-                      (.abort req))))))
+                            (:http-req @p-request)]
+                        (.abort req))))))
 
 
 (defn update-request-chan

--- a/src/kapibara/discovery.clj
+++ b/src/kapibara/discovery.clj
@@ -1,0 +1,62 @@
+(ns kapibara.discovery
+  "Facilities for discovering resources available in a Kubernetes cluster"
+  (:require [clojure.core.async :refer [<! >!] :as async]
+            [clojure.spec-alpha2 :as s]
+            [clojure.string :as str]
+
+            [lambdaisland.uri :refer [uri] :as uri]
+
+            [kapibara.core :as k]
+            [kapibara.resources :as res]
+            [kapibara.util :as util]))
+
+
+(defn distribute-list-group-version
+  [list]
+  (let [updater #(util/select-keys-via {:groupVersion identity} list %)]
+    (update list :resources #(map updater %))))
+
+
+(defn get-api-resources
+  [client group-version]
+  (k/request client {:method :get :uri (res/make-path group-version)}))
+
+
+(defn get-api-groups
+  [client]
+  (let [ch (async/chan)]
+    ;; FIXME: error handling for requests (if any error, die)
+    (async/go
+      (let [core-info (<! @(k/request client {:method :get :uri "/api"}))
+            groups (<! @(k/request client {:method :get :uri "/apis"}))
+            core-versions (into [] (map #(hash-map :groupVersion %
+                                                   :version %))
+                                (:versions core-info))
+            core-group {:name ""
+                        :versions core-versions
+                        :preferredVersion (get core-versions 0)}]
+        (>! ch (update groups :groups #(into [] (concat [core-group] %))))))
+    ;; FIXME: Implement aborting.
+    (k/->Request ch nil)))
+
+
+(comment
+  (do
+    (require '[clojure.core.async :refer [<!!]])
+    (def client (k/make-client "http://localhost:8080")))
+
+  (<!! @(get-api-resources client {:groupVersion "v1"}))
+  (<!! @(get-api-groups client))
+
+  (let [all-res (->> (<!! @(get-api-groups client))
+                     :groups
+                     (sequence (comp
+                                (map :preferredVersion)
+                                (map (partial get-api-resources client))
+                                (map deref)))
+                     async/merge
+                     (async/into [])
+                     (<!!))]
+    (reduce cache-api-resource-list {} all-res))
+
+  )

--- a/src/kapibara/discovery.clj
+++ b/src/kapibara/discovery.clj
@@ -1,7 +1,6 @@
 (ns kapibara.discovery
   "Facilities for discovering resources available in a Kubernetes cluster"
   (:require [clojure.core.async :refer [<! >!] :as async]
-            [clojure.spec-alpha2 :as s]
             [clojure.string :as str]
 
             [lambdaisland.uri :refer [uri] :as uri]

--- a/src/kapibara/http.clj
+++ b/src/kapibara/http.clj
@@ -1,39 +1,80 @@
 (ns kapibara.http
-  (:import [java.net.http HttpClient HttpRequest HttpClient$Version])
+  (:require [clojure.string :as str])
+  (:import [java.io InputStream]
+           [java.net.http
+            HttpClient
+            HttpClient$Builder
+            HttpClient$Version
+            HttpRequest
+            HttpRequest$Builder
+            HttpRequest$BodyPublisher
+            HttpRequest$BodyPublishers
+            HttpResponse$BodyHandler
+            HttpResponse$BodyHandlers
+            HttpResponse$BodySubscriber
+            HttpResponse$ResponseInfo]
 
-  )
+           [java.util.function Supplier]))
 
-(def ^:private versions
-  {:v1.1 HttpClient$Version/HTTP_1_1
-   :v2 HttpClient$Version/HTTP_2})
-
-;; TODO: Promote this namespace to a separate package.
 
 (defn client
   [options]
+  ;; TODO: Support the whole HttpClient(Builder) API
+  (-> (HttpClient/newBuilder)
+      .build))
 
-  ()
+(defn- coerce-to-string
+  [v]
+  (if (keyword? v) (subs (str v) 1) (str v)))
 
-  )
+(defn- apply-method
+  [^HttpRequest$Builder builder method body]
+  (let [method (str/upper-case (coerce-to-string method))
+        publisher (cond
+                    (instance? HttpRequest$BodyPublisher body) body
+                    ;; TODO: Support charset?
+                    (string? body) (HttpRequest$BodyPublishers/ofString body)
+                    (nil? body) (HttpRequest$BodyPublishers/noBody)
+                    :else (throw (ex-info "unsupported body type" {:body body})))]
+    (.method builder method publisher)))
+
+
+;; TODO: Maybe it's better to treat headers as headers, rather than doing
+;;       special handling for some.  If we want to give convenience, there could
+;;       be free-standing functions that header composition and prevent header
+;;       name typos.
+(defn- apply-content-type
+  [^HttpRequest$Builder builder content-type]
+  (if content-type
+    (.setHeader builder "Content-Type"  (coerce-to-string content-type))
+    builder))
+
 
 (defn request
-  [options]
-  )
+  [{:keys [body content-type method uri]}]
+  ;; TODO: Support the whole HttpRequest(Builder) API
+  (let [^HttpRequest$Builder builder (HttpRequest/newBuilder)]
+    (-> builder
+        (apply-method method body)
+        (apply-content-type content-type))
+    ;; TODO: Am I doing something wrong?  When using `->` or `doto`, the type
+    ;;       hint seems to be lost, and then these methods need to be done via
+    ;;       reflection, which fails since the builder objects are private.
+    (.uri builder uri)
+    (.build builder)))
 
 
 (defn send!
-  [req]
-  )
+  [^HttpClient client ^HttpRequest req]
+  (.send client req (HttpResponse$BodyHandlers/ofInputStream)))
 
-(defn send-async!
-  [req]
-  )
+
+;; (defn send-async!
+;;   [^HttpClient client ^HttpRequest req]
+;;   (.sendAsync client req))
 
 
 (comment
   (clojure.reflect/reflect HttpClient$Version)
-
-  (versions :v1.1)
-  (versions :v2)
 
   )

--- a/src/kapibara/http.clj
+++ b/src/kapibara/http.clj
@@ -1,0 +1,39 @@
+(ns kapibara.http
+  (:import [java.net.http HttpClient HttpRequest HttpClient$Version])
+
+  )
+
+(def ^:private versions
+  {:v1.1 HttpClient$Version/HTTP_1_1
+   :v2 HttpClient$Version/HTTP_2})
+
+;; TODO: Promote this namespace to a separate package.
+
+(defn client
+  [options]
+
+  ()
+
+  )
+
+(defn request
+  [options]
+  )
+
+
+(defn send!
+  [req]
+  )
+
+(defn send-async!
+  [req]
+  )
+
+
+(comment
+  (clojure.reflect/reflect HttpClient$Version)
+
+  (versions :v1.1)
+  (versions :v2)
+
+  )

--- a/src/kapibara/resources.clj
+++ b/src/kapibara/resources.clj
@@ -1,0 +1,200 @@
+(ns kapibara.resources
+  "Tools for working with resources using their resource definitions (eg, from
+  the `kapibara.discovery`).  Wraps the core Kapibara client to provide
+  convenient resource-centric requests."
+  (:require [clojure.data.json :as json]
+            [clojure.spec-alpha2 :as s]
+            [clojure.string :as str]
+
+            [lambdaisland.uri :refer [uri] :as uri]
+
+            [kapibara.core :as k]
+            [kapibara.util :as util]))
+
+
+(defn core-api?
+  [group-version]
+  (not (str/includes? group-version "/")))
+
+
+(defn specialize
+  [client resource]
+  (assoc client :resource resource))
+
+
+;; TODO: spec `make-path`
+(defn make-path
+  ([resource] (make-path resource nil))
+  ([resource options]
+   (if (and (not (:namespaced resource))
+            (some? (:namespace/name options)))
+     ;; TODO: throw an appropriate exception (maybe use spec?)
+     {:error (str "cannot use namespace with non-namespaced resource")}
+     (let [group-version (:groupVersion resource)
+           resource-name (:name resource)
+           ns (:namespace/name options)
+           name (:object/name options)
+           parts (if (core-api? group-version)
+                   ["/api" group-version]
+                   ["/apis" group-version])
+           parts (if-not ns parts
+                         (conj parts "namespaces" ns))
+           parts (if-not resource-name parts
+                         (conj parts (:name resource)))
+           parts (if-not name parts (conj parts name))]
+       (str/join "/" parts)))))
+
+
+(defn- apply-verb
+  [options resource]
+  ;; TODO: Validate verb/path combinations
+  (case (keyword (get options :verb :get))
+    :get
+    (assoc options :method :get)
+
+    :list
+    (assoc options :method :get)
+
+    :create
+    ;; TODO: better content-type, body encoding
+    (-> options
+        (assoc :method :post
+               :content-type :application/json)
+        (update :body #(if-not (string? %) (json/write-str %) %))
+        ;; FIXME: annoyingly, this dissoc for :object/name needs to be done
+        ;;        sooner, since :uri must already be filled before this function
+        ;;        runs
+        (dissoc :object/name))
+
+    :delete
+    (-> options
+        (assoc :method :delete)
+        ;; FIXME: It's strange to dissoc the body here.  Callers should not add
+        ;;        it, or if they do, we should encode it like in create/update
+        (dissoc :body))
+
+    :deletecollection
+    (assoc options :method :delete)
+
+    :patch
+    ;; TODO: content-type, body encoding
+    (assoc options :method :patch)
+
+    :update
+    ;; TODO: content-type, body encoding
+    (-> options
+        (assoc :method :put
+               :content-type :application/json)
+        (update :body #(if-not (string? %) (json/write-str %) %)))
+
+    :watch
+    (-> options
+        (assoc :method :get)
+        ;; TODO: This update could be more beautiful, somehow.
+        (update :uri #(uri/join % (->> (uri %)
+                                       :query
+                                       (util/split-query)
+                                       (remove (fn [[k]] (= k "watch")))
+                                       (concat [["watch" "true"]])
+                                       (util/join-query)))))))
+
+
+(defn request
+  ([client] (request client nil))
+  ([client options]
+   (let [resource (or (:resource options) (:resource client))
+         ;; FIXME: This is ugly.  I want it to be possible for this to happen in
+         ;;        apply-verb (see note there).
+         options (if (= :create (:verb options))
+                   (dissoc options :object/name)
+                   options)
+         uri (uri/join (make-path resource options)
+                       (:uri options))
+         options (-> options
+                     (assoc :uri uri)
+                     (apply-verb resource)
+                     (dissoc :resource
+                             :verb
+                             :namespace/name
+                             :object/name))]
+     (k/request client options))))
+
+
+(defn- list-kind->object-kind
+  [list-kind]
+  (str/replace list-kind #"List$" ""))
+
+
+(defn distribute-list-version-kind
+  [list]
+  (let [updater #(util/select-keys-via {:apiVersion identity
+                                        :kind list-kind->object-kind}
+                                       list %)]
+    (update list :items #(map updater %))))
+
+
+(def unpack-list
+  (comp (map :items)
+        cat))
+
+
+(comment
+
+  (do
+    (def configmaps {:groupVersion "v1"
+                     :name "configmaps"
+                     :namespaced true})
+
+    (def pvs {:groupVersion "v1"
+              :name "persistentvolumes"
+              :namespaced false})
+
+    (def namespaces {:groupVersion "v1"
+                     :name "namespaces"
+                     :namespaced false}))
+
+  (make-path configmaps {:namespace/name "default"})
+  (make-path configmaps {:namespace/name "default"
+                         :object/name "foo"})
+
+  ;; invalid (namespace not allowed)
+  (make-path pvs {:namespace/name "default"})
+
+  (make-path pvs)
+  (make-path pvs {:object/name "foo"})
+
+  (make-path namespaces)
+  (make-path namespaces {:object/name "default"})
+
+  (make-path {:groupVersion "v1"})
+  (make-path {:groupVersion "node.k8s.io/v1beta1"})
+
+  (list-kind->object-kind "ConfigMapList")
+
+  (def client (specialize (k/make-client "http://localhost:8080")
+                          configmaps))
+
+  (def req (request client {:namespace/name "default"
+                            :object/name "foo"
+                            :verb :get}))
+
+  (def req (request client {:namespace/name "default"
+                            :object/name "baz"
+                            :verb :delete}))
+
+  (clojure.core.async/<!! @req)
+
+  (k/abort! req)
+
+  (apply-verb {:verb :get} {})
+  (apply-verb {:verb "get"} {})
+
+  (apply-verb {:verb :watch
+               :uri "http://localhost:8080/api/v1/namespaces/default/configmaps"}
+              {})
+
+  (apply-verb {:verb :watch
+               :uri "http://localhost:8080?watch=false&fun=times"}
+              {})
+
+  )

--- a/src/kapibara/resources.clj
+++ b/src/kapibara/resources.clj
@@ -3,7 +3,6 @@
   the `kapibara.discovery`).  Wraps the core Kapibara client to provide
   convenient resource-centric requests."
   (:require [clojure.data.json :as json]
-            [clojure.spec-alpha2 :as s]
             [clojure.string :as str]
 
             [lambdaisland.uri :refer [uri] :as uri]

--- a/src/kapibara/util.clj
+++ b/src/kapibara/util.clj
@@ -1,0 +1,85 @@
+(ns kapibara.util
+  (:require [clojure.string :as str])
+  (:import [java.net URLEncoder URLDecoder]))
+
+
+(defn select-keys-via
+  ([spec from]
+   (select-keys-via spec from nil))
+  ([spec from to]
+   (loop [spec' spec
+          to' (transient to)]
+     (if-let [[k transform] (first spec')]
+       (let [v (get from k ::none)
+             to' (if (identical? v ::none)
+                   to'
+                   (assoc! to' k (transform v)))]
+         (recur (rest spec') to'))
+       (persistent! to')))))
+
+
+(defn split-group-version
+  [gv]
+  (let [[group-or-version maybe-version] (str/split gv #"/" 2)]
+    (if maybe-version
+      [group-or-version maybe-version]
+      ["" group-or-version])))
+
+
+(defn url-decode
+  [^String s]
+  (URLDecoder/decode s))
+
+
+(defn url-encode
+  [^String s]
+  (URLEncoder/encode s))
+
+
+(defn join-query
+  [parts]
+  (when (not-empty parts)
+    (->> (sequence (comp
+                    (map #(map url-encode %))
+                    (map #(str/join "=" %)))
+                   parts)
+         (str/join "&")
+         (str "?"))))
+
+
+(defn split-query
+  [s]
+  (when s
+    (as-> s x
+      (url-decode x)
+      (str/replace x #"^\?" "")
+      (str/split x #"[&]")
+      (map #(str/split % #"=") x))))
+
+
+(comment
+  (join-query [["x" "y"]
+               ["z" "great times"]])
+
+  (-> "?x=y&z=great+times"
+   (split-query)
+   (concat [["watch" "true"]])
+   (join-query))
+
+  (split-query nil)
+  (join-query nil)
+  (join-query [])
+
+
+  (select-keys-via {:foo identity
+                    :bar inc
+                    :baz dec}
+                   {:foo 5
+                    :bar 6
+                    :quux 99}
+                   {})
+
+  (split-group-version "v1")
+  (split-group-version "node.k8s.io/v1")
+
+  )

--- a/test/kapibara/core_test.clj
+++ b/test/kapibara/core_test.clj
@@ -1,0 +1,7 @@
+(ns kapibara.core-test
+  (:require [clojure.test :refer :all]
+            [kapibara.core :refer :all]))
+
+(deftest a-test
+  (testing "FIXME, I fail."
+    (is (= 0 1))))


### PR DESCRIPTION
# Kapibara, Round 1
## Introduction

Kapibara is a Clojure interface to the Kubernetes API.  It is intended to be used to build tools, daemons, and other things that interact with Kubernetes.

## Design

Above all, Kapibara tries to be simple and flexible.  Higher-level functionality is layered on more primitive functionality, but it is expected that some users will want to use the low-level parts directly:  they should not be hindered by decisions made to support higher-level parts of Kapibara.

### Core
`kapibara.core` contains the most basic, low-level facilities for connecting to Kubernetes.  At the moment, it only supports plain-HTTP, unauthenticated connections (`kubectl proxy` is recommended).

This module makes very few assumptions about how it will be used (for example, there is no special handling of request headers or bodies).  One notable exception is that response bodies are assumed to be streams of JSON documents, and are automatically decoded into Clojure data structures.  (Perhaps this should be moved into a medium-level part of the library.  But, for now it's very convenient.)

The main function of interest here is `kapibara.core/request`, which can execute any kind of HTTP request against a Kubernetes cluster and stream back the results over an `async/chan` (inside a `deref`-able `kapibara.core/Request`).

### Discovery
`kapibara.discovery` builds on the core client to provide API group discovery for resources that are available in a cluster.  It is expected that most applications will use resource definitions that were acquired this way.

It is unlikely that Kapibara will ever distribute modules that are generated from Kubernetes resource definitions.  It's a fruitless maintenance headache, and as the Kubernetes API becomes more extensible, the problem only gets worse.

Instead, facilities will be provided (not yet implemented!) to allows users of the library to connect to a cluster and create bespoke modules (saved in their own projects, not in Kapibara itself) that work with the exact API resources they have available.  In Clojure, we are used to working with a REPL, and Kubernetes is a highly self-describing system.  There's no reason to make things artificially static.

We should keep asking the question:  what do generated Clojure modules for Kubernetes API types get us?  (Better auto-completion is one thing, and maybe and easier time looking at swagger-generated documentation.  Is this enough?  Are there other reasons?  The dynamic interface is very convenient, otherwise.)

### Resources
`kapibara.resources` provides facilities that use the core client and (discovered) resource definitions to perform actions against a cluster.  This module understands the semantics of Kubernetes resource verbs (create, list, delete, update, watch, etc), and configures the core client to make appropriate requests for the resource+verb combination.  At the moment, this is likely to be where most users of this library spend most of their time.

## Caveats/Warts

- [ ] `kapibara.core/Request` holds an `async/chan` which it provides via `IDeref` (like, `(<! @req)`).  It's possible this is awkward, or an abuse of `IDeref`.  But, some kind of enclosing `deftype` seems necessary, so we can have a place to implement `kapibare.core/abort!`.
- [ ] `kapibara.core/Request` may be misnamed.  Maybe it is more like a `Connection`, since it can be `abort!`ed (which seems like request functionality), but also has a stream of response data in the `chan`.
- [ ] `clj-http` is being used, because of the HTTP libraries available for Clojure, it is the one that gave me enough control to implement abort-able requests.  It is huge, though, and it would be nice to use something else.
- [ ] Starting in JDK 11, the new async [HTTPClient](https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html) has been standardized.  Maybe we should implement a lightweight Clojure HTTP lib based on that (this is no small task).
- [ ] Not directly related to Kapibara, but part of the larger goals of Kapibara, Keel, and Tender:  `clj-http` is incompatible with native image generation via GraalVM.
- [ ] GraalVM currently does not support JDK 11 (JDK 8 is the latest), so even if we wanted to use the standard HTTPClient, it wouldn't help.  (GraalVM is [due for a release](https://www.graalvm.org/docs/release-notes/version-roadmap/) in late November 2019 with support for JDK 11).

---

That's about all I can think of for now.. Take a look around...

- Install Kind for a safe place to play:  https://github.com/kubernetes-sigs/kind
- Set your `KUBECONFIG` to point to your new Kind cluster
- Run `kubectl proxy`
- Play around with the comments at the bottom of each clj file